### PR TITLE
Major changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@ The formula has three parameters:
 ## Roles
 
 The Impact Hours app should implement the following roles:
-- **CLAIM_ROLE**: It allows to claim Hatch tokens by burning the Impact Hour tokens. Anyone should be able to claim.
+- **CLOSE_ROLE**: It allows to close the Hatch when all impact hours tokens have been claimed. Anyone should be able to close.
 
 The Impact Hours app should have the following roles:
 - **MINT_ROLE**: It should be able to mint tokens in the Hatch's Token Manager.
-
-The Impact Hours app can be used as ACL oracle for the following role:
-- **CLOSE_ROLE**: It can prevent calling the Hatch's `close()` function if all impact hours has not been claimed.
+- **CLOSE_ROLE**: It should be able to call the Hatch's `close()` function if all impact hours have been claimed.
 
 ## Interface
 

--- a/README.md
+++ b/README.md
@@ -10,24 +10,23 @@ The more funds that are raised, the higher the hourly wage for impact hours beco
 
 ## Initialization
 
-The Impact Hours is initialized with `MiniMeToken _token`, `address _hatch`, `uint256 _maxRate_`, and `uint256 _expectedRaisePerIH` parameters.
+The Impact Hours is initialized with `MiniMeToken _token`, `address _hatch`, `uint256 _maxRate_`, and `uint256 _expectedRaise` parameters.
 - The `MiniMeToken _token` is the address of the Impact Hours token.
 - The `address _hatch` parameter is the address of the Hatch that Impact Hours are for.
-- The `uint256 _maxRate` and `uint256 _expectedRaisePerIH` are used to determine how much tokens will be minted per IH based on the total raised amount.
+- The `uint256 _maxRate` and `uint256 _expectedRaise` are used to determine how much tokens will be minted per IH based on the total raised amount. We expect both of them are formatted as hatch's `contributionToken` (probably using 18 decimals).
 
 We determine the rate of each impact hour with the following formula where the independent variable (x) is the total funds raised:
 
-![R*x/(x+m*H)](https://forum.tecommons.org/uploads/default/original/1X/ed187f4401c6a8901199a6bf1e5916eec597905d.png)
+![R*x/(x+E)](https://render.githubusercontent.com/render/math?math=R\frac{x}{x+E})
 
-The formula has three parameters:
-* _H_ : Total number of impact hours.
-* _m_ : Expected raise per impact hour, in which the rate is half the max rate. A low number makes a more curved function, whereas a high number flattens the curve.
-* _R_ : Max IH rate limit. It’s an asymptotic limit never reached, no matter how much funds are raised.
+The formula has two parameters:
+* _R_ : Max rate limit per impact hour. It’s an asymptotic limit never reached, no matter how much funds are raised.
+* _E_ : Expected raise, in which the rate is half the max rate. A low number makes a more curved function, whereas a high number flattens the curve.
 
 ## Roles
 
-The Impact Hours app should implement the following roles:
-- **CLOSE_ROLE**: It allows to close the Hatch when all impact hours tokens have been claimed. Anyone should be able to close.
+The Impact Hours app implements the following role:
+- **CLOSE_ROLE**: It allows to close the Hatch when all impact hours tokens have been claimed.
 
 The Impact Hours app should have the following roles:
 - **MINT_ROLE**: It should be able to mint tokens in the Hatch's Token Manager.

--- a/arapp.json
+++ b/arapp.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Claim tokens",
-      "id": "CLAIM_ROLE",
+      "name": "Close hatch",
+      "id": "CLOSE_ROLE",
       "params": []
     }
   ],

--- a/contracts/IHatch.sol
+++ b/contracts/IHatch.sol
@@ -8,4 +8,5 @@ interface IHatch {
     function tokenManager() external view returns (TokenManager);
     function contributionToTokens(uint256 _value) external view returns (uint256);
     function totalRaised() external view returns (uint256);
+    function close() external;
 }

--- a/contracts/ImpactHours.sol
+++ b/contracts/ImpactHours.sol
@@ -15,41 +15,66 @@ contract ImpactHours is AragonApp {
     MiniMeToken public token;
     Hatch public hatch;
     uint256 public maxRate;
-    uint256 public expectedRaisePerIH;
-    uint256 public totalIH;
+    uint256 public expectedRaise;
 
     string private constant ERROR_HATCH_NOT_GOAL_REACHED = "IH_HATCH_NOT_GOAL_REACHED";
     string private constant ERROR_IMPACT_HOURS_NOT_FULLY_CLAIMED = "IH_NOT_FULLY_CLAIMED";
 
-    function initialize(MiniMeToken _token, address _hatch, uint256 _maxRate, uint256 _expectedRaisePerIH) external onlyInit {
+    /**
+     * @notice Initialize Impact Hours app with the `_token.symbol(): string` impact hours token, for the hatch `_hatch`, and with a max rate of `_maxRate` and an expected raise of `_expectedRaise`
+     * @dev We store a clone of the impact hours tokens that will be burn as soon as they are claimed
+     * @param _token Impact hours token
+     * @param _hatch Hatch to be closed
+     * @param _maxRate Max rate limit per impact hour
+     * @param _expectedRaise Expected raise, in which the rate is half the max rate
+     */
+    function initialize(MiniMeToken _token, address _hatch, uint256 _maxRate, uint256 _expectedRaise) external onlyInit {
         // We clone the IH token so we can burn it as soon as it is claimed
         token = _token.createCloneToken(_token.name(), _token.decimals(), _token.symbol(), 0, false);
         hatch = Hatch(_hatch);
         maxRate = _maxRate;
-        expectedRaisePerIH = _expectedRaisePerIH;
-        totalIH = token.totalSupply(); // We store a local copy of total amount of IH, because total supply will decrease as IH are claimed
+        expectedRaise = _expectedRaise;
         initialized();
     }
 
+    /**
+     * @notice Convert impact hour tokens into hatch tokens for multiple contributor addresses
+     * @dev We calculate how much tokens must be minted with the reward formula, burn cloned impact hours token so they can not be claimed again
+     * @param _contributors List of contributors 
+     */
     function claimReward(address[] _contributors) external isInitialized {
         require(hatch.state() == GOAL_REACHED, ERROR_HATCH_NOT_GOAL_REACHED);
         for (uint256 i = 0; i < _contributors.length; i++) {
-            uint256 _amount = hatch.contributionToTokens(reward(hatch.totalRaised(), _contributors[i]));
+            uint256 _amount = reward(hatch.totalRaised(), _contributors[i]);
             token.destroyTokens(_contributors[i], token.balanceOf(_contributors[i]));
             require(token.balanceOf(_contributors[i]) == 0); // All claimed tokens should be burned
             hatch.tokenManager().mint(_contributors[i], _amount);
         }
     }
 
+    /**
+     * @notice Close hatch
+     */
     function closeHatch() external auth(CLOSE_ROLE) {
         require(token.totalSupply() == 0, 'ERROR_IMPACT_HOURS_NOT_FULLY_CLAIMED');
         hatch.close();
     }
 
-    function reward(uint256 totalRaised, address contributor) public view isInitialized returns (uint256) {
-        if (totalRaised == 0) {
+    /**
+     * @dev Returns the amount of hatch tokens a contributor receives depending on the total raised by the hatch
+     * @param _totalRaised Total raised by the hatch
+     * @param _contributor Contributor with impact hours
+     */
+    function reward(uint256 _totalRaised, address _contributor) public view isInitialized returns (uint256) {
+        if (_totalRaised == 0) {
             return 0;
         }
-        return token.balanceOf(contributor).mul(maxRate).mul(totalRaised).div(totalRaised.add(expectedRaisePerIH.mul(totalIH)));
+        return hatch.contributionToTokens(
+            token.balanceOf(_contributor)
+                .mul(maxRate)
+                .div(10 ** uint256(token.decimals()))
+                .mul(_totalRaised)
+                .div(_totalRaised.add(expectedRaise))
+        );
     }
 }

--- a/contracts/test/mocks/HatchMock.sol
+++ b/contracts/test/mocks/HatchMock.sol
@@ -36,7 +36,7 @@ contract HatchMock is AragonApp {
         initialized();
     }
 
-    function contribute(uint256 _amount) {
+    function contribute(uint256 _amount) external {
         totalRaised = totalRaised.add(_amount);
     }
 

--- a/test/ImpactHours.js
+++ b/test/ImpactHours.js
@@ -15,13 +15,13 @@ const ZERO_ADDR = '0x' + '0'.repeat(40)
 contract(
   'ImpactHours',
   ([appManager, accountIH90, accountIH10]) => {
-    let impactHoursBase, tokenManagerBase, hatchBase, impactHours, hatch, hatchToken, impactHoursToken, tokenFactory
+    let impactHoursBase, tokenManagerBase, hatchBase, impactHours, hatch, hatchToken, impactHoursToken18, impactHoursToken10, tokenFactory
     let MINT_ROLE, CLOSE_ROLE
 
     const PPM = 1000000
     const EXCHANGE_RATE = 10 * PPM
     const MAX_RATE = 100
-    const EXPECTED_RAISE_PER_IH = 1
+    const EXPECTED_RAISE = bigExp(100, 18)
 
     before('deploy base apps', async () => {
       impactHoursBase = await ImpactHours.new()
@@ -33,9 +33,14 @@ contract(
     })
 
     before('create tokens', async () => {
-      impactHoursToken = await MiniMeToken.new(tokenFactory.address, ZERO_ADDR, 0, "Impact Hours", 18, "IH", false, { from: appManager })
-      await impactHoursToken.generateTokens(accountIH90, bigExp(90, 18))
-      await impactHoursToken.generateTokens(accountIH10, bigExp(10, 18))
+      const initializeToken = async (decimals) => {
+        const impactHoursToken = await MiniMeToken.new(tokenFactory.address, ZERO_ADDR, 0, "Impact Hours", decimals, "IH", false, { from: appManager })
+        await impactHoursToken.generateTokens(accountIH90, bigExp(90, decimals))
+        await impactHoursToken.generateTokens(accountIH10, bigExp(10, decimals))
+        return impactHoursToken
+      }
+      impactHoursToken18 = await initializeToken(18)
+      impactHoursToken10 = await initializeToken(10)
     })
 
     beforeEach('deploy dao and apps', async () => {
@@ -72,32 +77,32 @@ contract(
       await acl.createPermission(impactHours.address, hatch.address, CLOSE_ROLE, appManager)
     })
 
-    describe('initialize(MiniMeToken _token, address _hatch, uint256 _maxRate, uint256 _expectedRaisePerIH)', () => {
+    describe('initialize(MiniMeToken _token, address _hatch, uint256 _maxRate, uint256 _expectedRaise)', () => {
       beforeEach('initialize impact hours', async () => {
-        await impactHours.initialize(impactHoursToken.address, hatch.address, MAX_RATE, EXPECTED_RAISE_PER_IH)
+        await impactHours.initialize(impactHoursToken18.address, hatch.address, MAX_RATE, EXPECTED_RAISE)
       })
 
       it('sets variables as expected', async () => {
         const actualHatch = await impactHours.hatch()
         const actualMaxRate = await impactHours.maxRate()
-        const actualExpectedRaisePerIH = await impactHours.expectedRaisePerIH()
+        const actualExpectedRaise = await impactHours.expectedRaise()
         const hasInitialized = await impactHours.hasInitialized()
 
         assert.strictEqual(actualHatch, hatch.address)
         assert.strictEqual(actualMaxRate.toString(), MAX_RATE.toString())
-        assert.strictEqual(actualExpectedRaisePerIH.toString(), EXPECTED_RAISE_PER_IH.toString())
+        assert.strictEqual(actualExpectedRaise.toString(), EXPECTED_RAISE.toString())
         assert.isTrue(hasInitialized)
       })
 
       it('has cloned the token and the control is kept by the impact hours contract', async () => {
         const actualToken = await MiniMeToken.at(await impactHours.token())
-        assert.strictEqual(await actualToken.parentToken(), impactHoursToken.address)
+        assert.strictEqual(await actualToken.parentToken(), impactHoursToken18.address)
         assert.strictEqual(await actualToken.controller(), impactHours.address)
       })
 
       it('reverts on reinitialization', async () => {
         await assertRevert(
-          impactHours.initialize(impactHoursToken.address, hatch.address, MAX_RATE, EXPECTED_RAISE_PER_IH),
+          impactHours.initialize(impactHoursToken18.address, hatch.address, MAX_RATE, EXPECTED_RAISE),
           'INIT_ALREADY_INITIALIZED'
         )
       })
@@ -105,7 +110,7 @@ contract(
 
     describe('claimReward(address[] _contributors)', async () => {
       beforeEach('initialize impact hours', async () => {
-        await impactHours.initialize(impactHoursToken.address, hatch.address, MAX_RATE, EXPECTED_RAISE_PER_IH)
+        await impactHours.initialize(impactHoursToken18.address, hatch.address, MAX_RATE, EXPECTED_RAISE)
       })
 
       it('can not claim if state is Pending', async () => {
@@ -143,47 +148,57 @@ contract(
       })
     })
 
-    const amount = (ih, maxRate, expectedRaise, raised) => ih.mul(maxRate).mul(raised).div(raised.add(expectedRaise))
+    const reward = async (amount, tokenDecimals, maxRate, expectedRaise, raised) =>
+      await hatch.contributionToTokens(amount.mul(maxRate).div(bigExp(1, tokenDecimals)).mul(raised).div(raised.add(expectedRaise)))
     const loop = f => {
       for (let maxRate of [10, 100]) {
-        for (let expectedRaisePerIH of [100, 10000]) {
+        for (let expectedRaise of [100, 10000]) {
           for (let raised of [0, 1000, 100000000]) {
-            it(`maxRate = ${maxRate}, expectedRaisePerIH = ${expectedRaisePerIH}, totalRaised = ${raised}`, f(maxRate, expectedRaisePerIH, raised))
+            it(
+              `maxRate = ${maxRate}, expectedRaise = ${expectedRaise}, totalRaised = ${raised}`,
+              () => f(bigExp(maxRate, 18), bigExp(expectedRaise, 18), bigExp(raised, 18))
+            )
           }
         }
       }
     }
 
-    describe('reward(uint256 totalRaised, address contributor))', async() => {
-      loop((maxRate, expectedRaisePerIH, raised) => async() => {
-        await impactHours.initialize(impactHoursToken.address, hatch.address, maxRate, expectedRaisePerIH)
+    const rewardTest = (impactHoursTokenDecimals) => {
+      loop(async (maxRate, expectedRaise, raised) => {
+        impactHoursToken = impactHoursTokenDecimals === 18 ? impactHoursToken18 : impactHoursToken10
+        await impactHours.initialize(impactHoursToken.address, hatch.address, maxRate, expectedRaise)
         assertBn(
-          await impactHours.reward(bigExp(raised, 18), accountIH90),
-          amount(await impactHoursToken.balanceOf(accountIH90), bn(maxRate), bigExp(expectedRaisePerIH * 100, 18), bigExp(raised, 18))
+          await impactHours.reward(raised, accountIH90),
+          await reward(await impactHoursToken.balanceOf(accountIH90), impactHoursTokenDecimals, maxRate, expectedRaise, raised)
         )
         assertBn(
-          await impactHours.reward(bigExp(raised, 18), accountIH10),
-          amount(await impactHoursToken.balanceOf(accountIH10), bn(maxRate), bigExp(expectedRaisePerIH * 100, 18), bigExp(raised, 18))
+          await impactHours.reward(raised, accountIH10),
+          await reward(await impactHoursToken.balanceOf(accountIH10), impactHoursTokenDecimals, maxRate, expectedRaise, raised)
         )
       })
+    }
+
+    describe('reward(uint256 totalRaised, address contributor', () => {
+      context('Impact hours token with 18 decimals', () => rewardTest(18))
+      context('Impact hours token with 10 decimals', () => rewardTest(10))
     })
 
     describe('claimReward(address[] _contributors)', async() => {
-      loop((maxRate, expectedRaisePerIH, raised) => async() => {
+      loop(async (maxRate, expectedRaise, raised) => {
         await hatch.setState(3)
-        await hatch.contribute(bigExp(raised, 18))
-        await impactHours.initialize(impactHoursToken.address, hatch.address, maxRate, expectedRaisePerIH)
+        await hatch.contribute(raised)
+        await impactHours.initialize(impactHoursToken18.address, hatch.address, maxRate, expectedRaise)
         await impactHours.claimReward([accountIH90, accountIH10])
         for (let account of [accountIH90, accountIH10]) {
-          const contributedAmount = amount(await impactHoursToken.balanceOf(account), bn(maxRate), bigExp(expectedRaisePerIH * 100, 18), bigExp(raised, 18))
-          assertBn(await hatchToken.balanceOf(account), await hatch.contributionToTokens(contributedAmount))
+          const expectedReward = await reward(await impactHoursToken18.balanceOf(account), 18, maxRate, expectedRaise, raised)
+          assertBn(await hatchToken.balanceOf(account), expectedReward)
         }
       })
     })
 
     describe('closeHatch()', async() => {
       beforeEach('initialize impact hours', async () => {
-        await impactHours.initialize(impactHoursToken.address, hatch.address, MAX_RATE, EXPECTED_RAISE_PER_IH)
+        await impactHours.initialize(impactHoursToken18.address, hatch.address, MAX_RATE, EXPECTED_RAISE)
       })
 
       context('with permission', async() => {


### PR DESCRIPTION
* We don't use the app as an ACL oracle anymore.
* We use the app to close the hatch, adding the `CLOSE_ROLE`, and removing the unnecessary `CLAIM_ROLE`.
* We simplify the formula to get `expectedRaise` instead of `expectedRaisePerIH`, so we can deal better with decimals.
* The function `reward()` returns the amount of hatch tokens a contributor receives now.
* The parameter `maxRate` can have deciamals.
* Hatch token and impact hours token can have different decimals.
* The documentation is improved.